### PR TITLE
Updated nock to version 2.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,15 +3,20 @@
   "description": "CouchDB components for the NoFlo flow-based programming environment",
   "author": "Henri Bergius <henri.bergius@iki.fi>; Zeke Dean <zeke.dean@propulsion.io>",
   "version": "1.0.2",
-  "licenses": [{
-    "type": "MIT",
-    "url": "https://github.com/bergie/noflo/raw/master/LICENSE"
-  }],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/bergie/noflo/raw/master/LICENSE"
+    }
+  ],
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/noflo/noflo-couchdb.git"
+    "type": "git",
+    "url": "https://github.com/noflo/noflo-couchdb.git"
   },
-  "keywords": ["noflo","couchdb"],
+  "keywords": [
+    "noflo",
+    "couchdb"
+  ],
   "engines": {
     "node": ">=0.6.0"
   },
@@ -24,7 +29,7 @@
     "mocha": "~1.21.0",
     "chai": "~1.9.0",
     "coffeelint": "*",
-    "nock": "0.48.0"
+    "nock": "2.13.0"
   },
   "noflo": {
     "icon": "bitbucket-square",


### PR DESCRIPTION
:rocket:

nock just published version 2.13.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 277 commits (ahead by 277, behind by 0).
- [53388e8](https://github.com/pgte/nock/commit/53388e873321c126613a1f56eff871158105173b): v2.13.0
- [7635ca6](https://github.com/pgte/nock/commit/7635ca63444a9390f3eb544004e04ddf7901f338): Merge branch 'jshcrowthe-master'
- [d5272f3](https://github.com/pgte/nock/commit/d5272f324c9875d5501457e3aa0ad9e5524a0b8d): Remove throw error statement from test (copy paste error)
- [87367c6](https://github.com/pgte/nock/commit/87367c6559d5c1d5398fd6d8f9ce58fc922ece14): Test wording change
- [9bec2b6](https://github.com/pgte/nock/commit/9bec2b61870ba4f4cd827756e10cbdbe44e26535): Add query param length check to prevent false positives
- [af261e3](https://github.com/pgte/nock/commit/af261e3c2ec943859f55361be6130dc281038acd): added @ruimarinho as contributor
- [8ebeae8](https://github.com/pgte/nock/commit/8ebeae8e934709cdc51582d189eff4c96d2c655e): v2.12.0
- [f74f651](https://github.com/pgte/nock/commit/f74f6512470c794df56008c3c7eecbeaa7b14e0e): Merge branch 'seegno-forks-bugfix/auth-with-username-only'
- [16cfab4](https://github.com/pgte/nock/commit/16cfab46268bbc70a44a338122f17f8ecad09202): Fix authentication using username only
- [96a8504](https://github.com/pgte/nock/commit/96a85040e7b611aa1eade0d2fb0b5cd9311bec63): Use travis container infrastructure
- [4f4d62b](https://github.com/pgte/nock/commit/4f4d62b0290866fa5c0ddf53282871b61c93e110): Add support for node 4.0.0+
- [c7e1874](https://github.com/pgte/nock/commit/c7e1874cd8045cd2f3653fef253a9bc90805b86f): v2.11.0
- [3c70db0](https://github.com/pgte/nock/commit/3c70db007f9dfd687298cae627198f9297b993ff): removed node 4
- [e7e3c5b](https://github.com/pgte/nock/commit/e7e3c5bda2cc14d67130d62ede4814c216f51d9f): added node 4.0
- [f5e2d29](https://github.com/pgte/nock/commit/f5e2d29696805e4f399e8c638bda29a01a1a8717): Merge branch 'pwmckenna-propagatedataevents'

There are 250 commits in total. See the [full diff](https://github.com/pgte/nock/compare/165d6effd9b8187c903aabefc0ca9967beec7207...53388e873321c126613a1f56eff871158105173b).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
